### PR TITLE
add missing include

### DIFF
--- a/src/SplitCode.h
+++ b/src/SplitCode.h
@@ -18,6 +18,7 @@
 #include <stack>
 #include <cmath>
 #include <iomanip>
+#include <cstdint>
 
 #if defined(_MSVC_LANG)
 #define SPLITCODE_CPP_VERSION _MSVC_LANG


### PR DESCRIPTION
Fixes building project with GCC 13.3.0
This failure occurs because to definitions of `stdints` in the `std` namespace being contained in the `cstdint` header.
Closes #27 